### PR TITLE
fix missing sys/ttydefaults.h header on alpine

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,8 @@ AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([pthread library not
 AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_ERROR([dl library not found])])
 AC_CHECK_LIB([sqlite3], [sqlite3_open], [], [AC_MSG_ERROR([sqlite3 library not found])])
 
+AC_CHECK_HEADER([sys/ttydefaults.h])
+
 AC_DEFINE_UNQUOTED([COMPILER_NAME], ["$CC"], [Name of the C compiler])
 AC_DEFINE_UNQUOTED([COMPILER_VERSION], ["`$CC --version | head -n1`"], [Version of the C compiler])
 AC_DEFINE_UNQUOTED([COMPILER_PATH], ["`which $CC`"], [Full path to the C compiler])

--- a/src/forge-headers-src/forge-chooser.c
+++ b/src/forge-headers-src/forge-chooser.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <termios.h>
 #include <string.h>
+#include <sys/ttydefaults.h>
 
 #include "forge/chooser.h"
 #include "forge/ctrl.h"


### PR DESCRIPTION
Tested only on alpine, but should work everywhere