### PR TITLE
Rewrite forge_cstr_of_int

### DIFF
--- a/src/forge-headers-src/forge-cstr.c
+++ b/src/forge-headers-src/forge-cstr.c
@@ -86,20 +86,13 @@ forge_cstr_last_of(const char *s, char c)
 char *
 forge_cstr_of_int(int i)
 {
-        int digits = 0;
-        if (i < 10)         digits = 1;
-        if (i < 100)        digits = 2;
-        if (i < 1000)       digits = 3;
-        if (i < 10000)      digits = 4;
-        if (i < 100000)     digits = 5;
-        if (i < 1000000)    digits = 6;
-        if (i < 10000000)   digits = 7;
-        if (i < 100000000)  digits = 8;
-        if (i < 1000000000) digits = 9;
-        else digits = 10;
+        char buf[12]; // 11 characters in INT_MIN and \0
+        int len = snprintf(buf, sizeof(buf), "%d", i);
+        if (len < 0) return NULL;
 
-        char *s = (char *)malloc(digits + 1);
-        sprintf(s, "%d", i);
-        s[digits-1] = 0;
+        char *s = malloc(len + 1);
+        if (!s) return NULL;
+
+        memcpy(s, buf, len + 1);
         return s;
 }


### PR DESCRIPTION
Previous implementation didn't handle negative values and possibly had off by one error in `s[digits-1] = 0`, this commit rewrites `forge_cstr_of_int` to use snprintf along with memcpy and removes extra null terminator as it's already appended by snprintf